### PR TITLE
EE-959 - Added composer no_dev

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -93,6 +93,9 @@ magento2_setup_parameters:
   - name: use-rewrites
     value: "1"
 
+# Skip installing packages listed in require-dev
+magento2_composer_no_dev: yes
+
 # WIP:
 magento2_magento_cli_commands:
   - setup:upgrade

--- a/tasks/installation-composer.yml
+++ b/tasks/installation-composer.yml
@@ -19,5 +19,6 @@
   composer:
     command: Install
     working_dir: "{{ magento2_installation_parent }}/{{ magento2_installation_name }}"
+    no_dev: "{{ magento2_composer_no_dev }}"
   tags: ['composer']
   when: var_magento2_installation_name.stat.exists

--- a/tasks/installation-git.yml
+++ b/tasks/installation-git.yml
@@ -37,6 +37,7 @@
   composer:
     command: install
     working_dir: "{{ magento2_installation_parent }}/{{ magento2_installation_name }}"
+    no_dev: "{{ magento2_composer_no_dev }}"
   tags: ['composer']
 
 - name: Set proper ownwernship of repository files.


### PR DESCRIPTION
Hi, this commit added "magento2_composer_no_dev" variable, default value is "yes" and can be overrided to install composer "require-dev" packages during role run.